### PR TITLE
Converting module to use license-checker in place of nlf.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-const nlf = require('nlf');
 const fs = require('fs');
 const minimist = require('minimist');
 const _ = require('lodash');
@@ -46,10 +45,12 @@ lc.init({ start: directory, production }, (err, npmPackages) => {
     exit(err);
   }
 
-  const builders = [new TextBuilder(), new JSONBuilder()];
+  const jsonBuilder = new JSONBuilder();
+  const builders = [new TextBuilder(), jsonBuilder];
 
   _.forEach(npmPackages, (npmPackage, nameVer) => {
-    const [name, version] = [_.initial(nameVer.split('@')).join('@'), _.last(nameVer.split('@'))];
+    const name = _.initial(nameVer.split('@')).join('@');
+    const version = _.last(nameVer.split('@'));
 
     npmPackage.name = npmPackage.name ? npmPackage.name : name;
     npmPackage.version = npmPackage.version ? npmPackage.version : version;
@@ -58,7 +59,7 @@ lc.init({ start: directory, production }, (err, npmPackages) => {
     }
 
     const packageID = nameVer;
-    const licenseFile = _.get(npmPackage, 'licenseFile', '');
+    const licenseFile = npmPackage.licenseFile || '';
 
     let hasReadme = false;
     if (!readme) {
@@ -108,7 +109,7 @@ lc.init({ start: directory, production }, (err, npmPackages) => {
         builder.addEmpty(name, version);
       });
     }
-    promises.push(builders[1].buildLink(name, npmPackage.repository, npmPackage.licenseFile));
+    promises.push(jsonBuilder.buildLink(name, npmPackage.repository, npmPackage.licenseFile));
   });
   
   Promise.all(promises).then(() => {

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const minimist = require('minimist');
 const _ = require('lodash');
 const chalk = require('chalk');
+const lc = require('license-checker');
 
 const { TextBuilder, JSONBuilder } = require('./lib/builders');
 const { exit } = require('./lib/util');
@@ -24,11 +25,13 @@ if (argv.help) {
   console.log('--cacheFile=<path>       An absolute path to a JSON cache file for looking up missing licenses.');
   console.log('--ignore=<name1, name2>  Comma separated package names to ignore.');
   console.log('--production             Search for licenses on production dependencies. Default is development.');
+  console.log('--readme                 Use the readme as a fallback when LICENSE is not available.');
   console.log('--help                   This help.');
   process.exit(0);
 }
 
 const production = !!argv.production;
+const readme = !!argv.readme;
 const { directory, cacheFile, ignore } = argv;
 
 const ignoreSet = ignore ? new Set(ignore.split(',')) : new Set();
@@ -36,25 +39,40 @@ const cache = cacheFile ? JSON.parse(fs.readFileSync(cacheFile, 'utf-8')) : null
 
 console.log(`Searching for ${production ? 'production' : 'development'} licenses in ${directory}`);
 
-nlf.find({ directory, production }, (err, npmPackages) => {
+let promises = [];
+
+lc.init({ start: directory, production }, (err, npmPackages) => {
   if (err) {
     exit(err);
   }
 
   const builders = [new TextBuilder(), new JSONBuilder()];
 
-  npmPackages.forEach(npmPackage => {
-    const { name, version } = npmPackage;
+  _.forEach(npmPackages, (npmPackage, nameVer) => {
+    const [name, version] = [_.initial(nameVer.split('@')).join('@'), _.last(nameVer.split('@'))];
 
+    npmPackage.name = npmPackage.name ? npmPackage.name : name;
+    npmPackage.version = npmPackage.version ? npmPackage.version : version;
     if (ignoreSet.has(name)) {
       return;
     }
 
-    const packageID = TextBuilder.getPackageIdentifier(npmPackage);
-    const sources = _.get(npmPackage, 'licenseSources.license.sources', []);
+    const packageID = nameVer;
+    const licenseFile = _.get(npmPackage, 'licenseFile', '');
 
-    if (sources.length > 0) {
+    let hasReadme = false;
+    if (!readme) {
+      hasReadme = licenseFile.toLowerCase().indexOf('readme') > -1;
+      if (hasReadme) {
+        npmPackage.licenseFile = '';
+      }
+    }
+
+    const text = licenseFile.length > 0 && (readme || !hasReadme) ? fs.readFileSync(licenseFile, 'utf-8') : null;
+
+    if (licenseFile.length > 0 && text) {
       builders.forEach(builder => {
+        npmPackage.text = text;
         builder.add(npmPackage);
       });
     } else if (cache && _.get(cache, [name, version], null)) {
@@ -73,18 +91,16 @@ nlf.find({ directory, production }, (err, npmPackages) => {
       builders.forEach(builder => {
         builder.addCached(name, version, lastVersionDefinition);
       });
-    } else if (_.get(npmPackage, 'licenseSources.package.sources', []).length > 0) {
-      const packageSources = _.get(npmPackage, 'licenseSources.package.sources', [])
-        .map(({ license }) => license)
-        .join(', ');
+    } else if (_.get(npmPackage, 'license', '').length > 0) {
+      const packagelicenseFile = `${_.get(npmPackage, 'license')}`;
 
       console.log(
-        chalk.red(`License source not found for ${packageID}, derived license types are: ${packageSources}.`)
+        chalk.red(`License source not found for ${packageID}, derived license types are: ${packagelicenseFile}.`)
       );
 
       builders.forEach(builder => {
         builder.addEmpty(name, version);
-      });
+      }); 
     } else {
       console.log(chalk.red(`License could not be detected for package ${packageID}.`));
 
@@ -92,9 +108,12 @@ nlf.find({ directory, production }, (err, npmPackages) => {
         builder.addEmpty(name, version);
       });
     }
+    promises.push(builders[1].buildLink(name, npmPackage.repository, npmPackage.licenseFile));
   });
-
-  builders.forEach(builder => {
-    builder.write();
+  
+  Promise.all(promises).then(() => {
+    builders.forEach(builder => {
+      builder.write();
+    });
   });
 });

--- a/lib/builders.js
+++ b/lib/builders.js
@@ -1,5 +1,7 @@
 const fs = require('fs');
 const chalk = require('chalk');
+const request = require('request-promise');
+_ = require('lodash');
 
 const { exit } = require('./util');
 
@@ -32,19 +34,20 @@ class TextBuilder {
     const packageID = TextBuilder.getPackageIdentifier({ name, version });
 
     this.output += TextBuilder.getPackageHeader(packageID);
-    this.output += formatLicenseText(text);
+    if (text) {
+      this.output += formatLicenseText(text);
+    }
     this.output += '\n\n';
   }
 
   add(npmPackage) {
     const packageID = TextBuilder.getPackageIdentifier(npmPackage);
-    const sources = npmPackage.licenseSources.license.sources;
 
     this.output += TextBuilder.getPackageHeader(packageID);
 
-    sources.forEach(({ text }) => {
-      this.output += formatLicenseText(text);
-    });
+    if (npmPackage.text) {
+      this.output += formatLicenseText(npmPackage.text);
+    }
 
     this.output += '\n\n';
   }
@@ -79,11 +82,36 @@ class JSONBuilder {
 
   add(npmPackage) {
     const { name, version } = npmPackage;
-    const sources = npmPackage.licenseSources.license.sources;
 
-    const licenseText = formatLicenseText(sources.reduce((acc, source) => `${acc}${source.text}`, ''));
+    const licenseText = npmPackage.text ? formatLicenseText(npmPackage.text) : '';
 
     this.addCached(name, version, licenseText);
+  }
+
+  buildLink(name, repository, licenseFile) {
+    return new Promise((resolve) => {
+      let licenseLink;
+      
+      if (licenseFile && repository) {
+        const licFileSegments = licenseFile.split('/');
+        const repoSegments = repository.split('/');
+        
+        licenseLink = `${repository}/blob/master/${licFileSegments[licFileSegments.length - 1]}`;
+        
+        request.get(licenseLink).then(
+          () => {
+            this.output[name].repository = licenseLink;
+            resolve(licenseLink);
+          },
+          (err) => {
+            console.log('bad', licenseLink);
+            resolve(null);
+          }
+        );
+      } else {
+        return resolve(null);
+      }
+    });
   }
 
   addEmpty(name, version) {
@@ -91,6 +119,7 @@ class JSONBuilder {
   }
 
   write() {
+    this._notifyMissing();
     fs.writeFile('licenses.json', JSON.stringify(this.output, null, 2), error => {
       if (error) {
         exit(error);
@@ -98,6 +127,28 @@ class JSONBuilder {
 
       console.log(chalk.green('Wrote JSON licenses to licenses.json'));
     });
+  }
+
+  _notifyMissing() {
+    let empties = [], missingRepos = [];
+    _.forEach(this.output, (pkg, pkgName) => {
+      if (!pkg[_.keys(_.omit(pkg, 'repository'))[0]]) {
+        empties.push(pkgName);
+      } else if (!pkg.repository) {
+        missingRepos.push(pkgName);
+      }
+    });
+
+    if (!_.isEmpty(missingRepos)) {
+      console.log(
+        chalk.yellow(`The following packages did not have a verifiable online LICENSE link: ${missingRepos.toString().replace(',', '\n')}`),
+      );
+    }
+    if (!_.isEmpty(empties)) {
+      console.log(
+        chalk.red(`The following packages did not have a local LICENSE file OR a LICENSE file/text in cache: ${empties.toString().replace(',', '\n')}`)
+      );
+    }
   }
 }
 

--- a/lib/builders.js
+++ b/lib/builders.js
@@ -1,25 +1,25 @@
-const fs = require('fs');
-const chalk = require('chalk');
-const request = require('request-promise');
-_ = require('lodash');
+const fs = require("fs");
+const chalk = require("chalk");
+const axios = require("axios");
+_ = require("lodash");
 
-const { exit } = require('./util');
+const { exit } = require("./util");
 
 function formatLicenseText(text) {
-  return text.trim().replace(/\r/g, '');
+  return text.trim().replace(/\r/g, "");
 }
 
 class TextBuilder {
   constructor() {
-    this.output = '';
+    this.output = "";
   }
 
   static getPackageHeader(packageID) {
-    let header = '';
+    let header = "";
 
-    header += '=====================================================\n';
+    header += "=====================================================\n";
     header += `${packageID}\n`;
-    header += '=====================================================\n';
+    header += "=====================================================\n";
 
     return header;
   }
@@ -37,7 +37,7 @@ class TextBuilder {
     if (text) {
       this.output += formatLicenseText(text);
     }
-    this.output += '\n\n';
+    this.output += "\n\n";
   }
 
   add(npmPackage) {
@@ -49,20 +49,20 @@ class TextBuilder {
       this.output += formatLicenseText(npmPackage.text);
     }
 
-    this.output += '\n\n';
+    this.output += "\n\n";
   }
 
   addEmpty(name, version) {
-    this.addCached(name, version, '');
+    this.addCached(name, version, "");
   }
 
   write() {
-    fs.writeFile('licenses.txt', this.output, error => {
+    fs.writeFile("licenses.txt", this.output, error => {
       if (error) {
         exit(error);
       }
 
-      console.log(chalk.green('Wrote text licenses to licenses.txt'));
+      console.log(chalk.green("Wrote text licenses to licenses.txt"));
     });
   }
 }
@@ -83,56 +83,59 @@ class JSONBuilder {
   add(npmPackage) {
     const { name, version } = npmPackage;
 
-    const licenseText = npmPackage.text ? formatLicenseText(npmPackage.text) : '';
+    const licenseText = npmPackage.text
+      ? formatLicenseText(npmPackage.text)
+      : "";
 
     this.addCached(name, version, licenseText);
   }
 
-  buildLink(name, repository, licenseFile) {
-    return new Promise((resolve) => {
-      let licenseLink;
-      
-      if (licenseFile && repository) {
-        const licFileSegments = licenseFile.split('/');
-        const repoSegments = repository.split('/');
-        
-        licenseLink = `${repository}/blob/master/${licFileSegments[licFileSegments.length - 1]}`;
-        
-        request.get(licenseLink).then(
-          () => {
-            this.output[name].repository = licenseLink;
-            resolve(licenseLink);
-          },
-          (err) => {
-            console.log('bad', licenseLink);
-            resolve(null);
-          }
-        );
-      } else {
-        return resolve(null);
+  async buildLink(name, repository, licenseFile) {
+    if (licenseFile && repository) {
+      const licFileSegments = licenseFile.split("/");
+
+      const licenseLink = `${repository}/blob/master/${
+        licFileSegments[licFileSegments.length - 1]
+      }`;
+
+      try {
+        await axios.get(licenseLink);
+      } catch(err) {
+        console.log("bad", licenseLink);
+        return null;
       }
-    });
+
+      this.output[name].repository = licenseLink;
+      return licenseLink;
+    } else {
+      return null;
+    }
   }
 
   addEmpty(name, version) {
-    this.addCached(name, version, '');
+    this.addCached(name, version, "");
   }
 
   write() {
     this._notifyMissing();
-    fs.writeFile('licenses.json', JSON.stringify(this.output, null, 2), error => {
-      if (error) {
-        exit(error);
-      }
+    fs.writeFile(
+      "licenses.json",
+      JSON.stringify(this.output, null, 2),
+      error => {
+        if (error) {
+          exit(error);
+        }
 
-      console.log(chalk.green('Wrote JSON licenses to licenses.json'));
-    });
+        console.log(chalk.green("Wrote JSON licenses to licenses.json"));
+      }
+    );
   }
 
   _notifyMissing() {
-    let empties = [], missingRepos = [];
+    let empties = [],
+      missingRepos = [];
     _.forEach(this.output, (pkg, pkgName) => {
-      if (!pkg[_.keys(_.omit(pkg, 'repository'))[0]]) {
+      if (!pkg[_.keys(_.omit(pkg, "repository"))[0]]) {
         empties.push(pkgName);
       } else if (!pkg.repository) {
         missingRepos.push(pkgName);
@@ -141,12 +144,20 @@ class JSONBuilder {
 
     if (!_.isEmpty(missingRepos)) {
       console.log(
-        chalk.yellow(`The following packages did not have a verifiable online LICENSE link: ${missingRepos.toString().replace(',', '\n')}`),
+        chalk.yellow(
+          `The following packages did not have a verifiable online LICENSE link: ${missingRepos
+            .toString()
+            .replace(",", "\n")}`
+        )
       );
     }
     if (!_.isEmpty(empties)) {
       console.log(
-        chalk.red(`The following packages did not have a local LICENSE file OR a LICENSE file/text in cache: ${empties.toString().replace(',', '\n')}`)
+        chalk.red(
+          `The following packages did not have a local LICENSE file OR a LICENSE file/text in cache: ${empties
+            .toString()
+            .replace(",", "\n")}`
+        )
       );
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,14 @@
 {
   "name": "js-license-generator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "acorn": {
       "version": "5.5.3",
       "resolved": "https://npm.lab.128technology.com/acorn/-/acorn-5.5.3.tgz",
@@ -77,6 +82,11 @@
         "sprintf-js": "1.0.3"
       }
     },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://npm.lab.128technology.com/array-union/-/array-union-1.0.2.tgz",
@@ -102,6 +112,34 @@
       "version": "2.0.6",
       "resolved": "https://npm.lab.128technology.com/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -146,6 +184,19 @@
       "resolved": "https://npm.lab.128technology.com/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://npm.lab.128technology.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -174,6 +225,11 @@
       "resolved": "https://npm.lab.128technology.com/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "2.3.2",
@@ -231,6 +287,14 @@
       "resolved": "https://npm.lab.128technology.com/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "combined-stream": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://npm.lab.128technology.com/commander/-/commander-2.9.0.tgz",
@@ -269,8 +333,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://npm.lab.128technology.com/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "d": {
       "version": "1.0.0",
@@ -279,6 +342,14 @@
       "dev": true,
       "requires": {
         "es5-ext": "0.10.40"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
       }
     },
     "debug": {
@@ -316,6 +387,11 @@
         "rimraf": "2.6.2"
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
     "dezalgo": {
       "version": "1.0.3",
       "resolved": "https://npm.lab.128technology.com/dezalgo/-/dezalgo-1.0.3.tgz",
@@ -332,6 +408,15 @@
       "dev": true,
       "requires": {
         "esutils": "2.0.2"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "error-ex": {
@@ -646,11 +731,31 @@
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
     "fast-diff": {
       "version": "1.1.2",
       "resolved": "https://npm.lab.128technology.com/fast-diff/-/fast-diff-1.1.2.tgz",
       "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
       "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -700,6 +805,21 @@
         "write": "0.2.1"
       }
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.7",
+        "mime-types": "2.1.21"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://npm.lab.128technology.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -731,6 +851,14 @@
       "resolved": "https://npm.lab.128technology.com/get-stdin/-/get-stdin-5.0.1.tgz",
       "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
       "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
     },
     "glob": {
       "version": "7.1.2",
@@ -784,6 +912,33 @@
       "resolved": "https://npm.lab.128technology.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "requires": {
+        "ajv": "6.7.0",
+        "har-schema": "2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+          "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
+          "requires": {
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
+          }
+        }
+      }
+    },
     "has": {
       "version": "1.0.1",
       "resolved": "https://npm.lab.128technology.com/has/-/has-1.0.1.tgz",
@@ -811,6 +966,16 @@
       "version": "2.6.0",
       "resolved": "https://npm.lab.128technology.com/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
       "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.16.0"
+      }
     },
     "ignore": {
       "version": "3.3.7",
@@ -892,6 +1057,11 @@
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
+    "ip-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-3.0.0.tgz",
+      "integrity": "sha512-T8wDtjy+Qf2TAPDQmBp0eGKJ8GavlWlUnamr3wRn6vvdZlKVuJXXMlSncYFRYgVHOM3If5NR1H4+OvVQU9Idvg=="
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://npm.lab.128technology.com/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -970,11 +1140,21 @@
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://npm.lab.128technology.com/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jest-docblock": {
       "version": "21.2.0",
@@ -998,10 +1178,25 @@
         "esprima": "4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
     "json-parse-better-errors": {
       "version": "1.0.1",
       "resolved": "https://npm.lab.128technology.com/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
       "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -1011,6 +1206,11 @@
       "requires": {
         "jsonify": "0.0.0"
       }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonify": {
       "version": "0.0.0",
@@ -1024,6 +1224,17 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://npm.lab.128technology.com/levn/-/levn-0.3.0.tgz",
@@ -1032,6 +1243,48 @@
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
+      }
+    },
+    "license-checker": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/license-checker/-/license-checker-25.0.1.tgz",
+      "integrity": "sha512-mET5AIwl7MR2IAKYYoVBBpV0OnkKQ1xGj2IMMeEFIs42QAkEVjRtFZGWmQ28WeU7MP779iAgOaOy93Mn44mn6g==",
+      "requires": {
+        "chalk": "2.4.2",
+        "debug": "3.2.6",
+        "mkdirp": "0.5.1",
+        "nopt": "4.0.1",
+        "read-installed": "4.0.3",
+        "semver": "5.5.0",
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0",
+        "spdx-satisfies": "4.0.1",
+        "treeify": "1.1.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "load-json-file": {
@@ -1069,6 +1322,19 @@
       "resolved": "https://npm.lab.128technology.com/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
+    "mime-db": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+    },
+    "mime-types": {
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "requires": {
+        "mime-db": "1.37.0"
+      }
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://npm.lab.128technology.com/minimatch/-/minimatch-3.0.4.tgz",
@@ -1086,7 +1352,6 @@
       "version": "0.5.1",
       "resolved": "https://npm.lab.128technology.com/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -1094,8 +1359,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://npm.lab.128technology.com/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -1129,6 +1393,15 @@
         "read-installed": "4.0.3"
       }
     },
+    "nopt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+      "requires": {
+        "abbrev": "1.1.1",
+        "osenv": "0.1.5"
+      }
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://npm.lab.128technology.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -1145,6 +1418,11 @@
       "resolved": "https://npm.lab.128technology.com/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -1183,8 +1461,21 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://npm.lab.128technology.com/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "p-limit": {
       "version": "1.2.0",
@@ -1254,6 +1545,11 @@
         "pify": "2.3.0"
       }
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://npm.lab.128technology.com/pify/-/pify-2.3.0.tgz",
@@ -1313,6 +1609,21 @@
       "resolved": "https://npm.lab.128technology.com/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
+    },
+    "psl": {
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "read-installed": {
       "version": "4.0.3",
@@ -1418,6 +1729,73 @@
         "resolve": "1.5.0"
       }
     },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.7",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.3",
+        "har-validator": "5.1.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.21",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "requires": {
+            "psl": "1.1.31",
+            "punycode": "1.4.1"
+          }
+        }
+      }
+    },
+    "request-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
+      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "requires": {
+        "bluebird": "3.5.3",
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "3.0.0"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "4.17.5"
+      }
+    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://npm.lab.128technology.com/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -1480,8 +1858,12 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://npm.lab.128technology.com/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "5.5.0",
@@ -1515,6 +1897,16 @@
       "resolved": "https://npm.lab.128technology.com/slide/-/slide-1.1.6.tgz",
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
+    "spdx-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
+      "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
+      "requires": {
+        "array-find-index": "1.0.2",
+        "spdx-expression-parse": "3.0.0",
+        "spdx-ranges": "2.0.0"
+      }
+    },
     "spdx-correct": {
       "version": "3.0.0",
       "resolved": "https://npm.lab.128technology.com/spdx-correct/-/spdx-correct-3.0.0.tgz",
@@ -1543,11 +1935,47 @@
       "resolved": "https://npm.lab.128technology.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
       "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
     },
+    "spdx-ranges": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.0.0.tgz",
+      "integrity": "sha512-AUUXLfqkwD7GlzZkXv8ePPCpPjeVWI9xJCfysL8re/uKb6H10umMnC7bFRsHmLJan4fslUtekAgpHlSgLc/7mA=="
+    },
+    "spdx-satisfies": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-4.0.1.tgz",
+      "integrity": "sha512-WVzZ/cXAzoNmjCWiEluEA3BjHp5tiUmmhn9MK+X0tBbR9sOqtC6UQwmgCNrAIZvNlMuBUYAaHYfb2oqlF9SwKA==",
+      "requires": {
+        "spdx-compare": "1.0.0",
+        "spdx-expression-parse": "3.0.0",
+        "spdx-ranges": "2.0.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://npm.lab.128technology.com/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "sshpk": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
+      "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
+      "requires": {
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "string-width": {
       "version": "1.0.2",
@@ -1699,6 +2127,34 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "tough-cookie": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.0.tgz",
+      "integrity": "sha512-LHMvg+RBP/mAVNqVbOX8t+iJ+tqhBA/t49DuI7+IDAWHrASnesqSu1vWbKB7UrE2yk+HMFUBMadRGMkB4VCfog==",
+      "requires": {
+        "ip-regex": "3.0.0",
+        "psl": "1.1.31",
+        "punycode": "2.1.1"
+      }
+    },
+    "treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A=="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://npm.lab.128technology.com/type-check/-/type-check-0.3.2.tgz",
@@ -1713,6 +2169,14 @@
       "resolved": "https://npm.lab.128technology.com/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "2.1.1"
+      }
     },
     "user-home": {
       "version": "2.0.0",
@@ -1734,6 +2198,11 @@
       "resolved": "https://npm.lab.128technology.com/util-extend/-/util-extend-1.0.3.tgz",
       "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
     },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
     "validate-npm-package-license": {
       "version": "3.0.3",
       "resolved": "https://npm.lab.128technology.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
@@ -1741,6 +2210,16 @@
       "requires": {
         "spdx-correct": "3.0.0",
         "spdx-expression-parse": "3.0.0"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -20,13 +20,11 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
+    "axios": "^0.18.0",
     "chalk": "^2.3.2",
     "license-checker": "^25.0.1",
     "lodash": "^4.17.5",
-    "minimist": "^0.1.0",
-    "nlf": "^1.4.3",
-    "request": "^2.88.0",
-    "request-promise": "^4.2.2"
+    "minimist": "^0.1.0"
   },
   "devDependencies": {
     "prettier": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "author": "128 Technology",
   "license": "MIT",
   "private": true,
-  "files": ["index.js"],
+  "files": [
+    "index.js"
+  ],
   "bin": {
     "js-license-generator": "index.js"
   },
@@ -19,9 +21,12 @@
   },
   "dependencies": {
     "chalk": "^2.3.2",
+    "license-checker": "^25.0.1",
     "lodash": "^4.17.5",
     "minimist": "^0.1.0",
-    "nlf": "^1.4.3"
+    "nlf": "^1.4.3",
+    "request": "^2.88.0",
+    "request-promise": "^4.2.2"
   },
   "devDependencies": {
     "prettier": "^1.11.1",


### PR DESCRIPTION
Made necessary changes to index.js and builders.js maintain functionality with the new package.
Added a --readme flag that allows us to explicitly specify if we will allow README.md files in place of missing LICENSE files
Added a check against URLs that commonly point to package LICENSE files so that we can include the online link in the JSON output.